### PR TITLE
Add ifdefs to exclude DS3232

### DIFF
--- a/src/SmallRTC.h
+++ b/src/SmallRTC.h
@@ -48,7 +48,9 @@
 */
 
 #include <TimeLib.h>
+#ifndef SMALL_RTC_NO_DS3232
 #include <DS3232RTC.h>
+#endif
 #include <Rtc_Pcf8563.h>
 #include <Wire.h>
 #include <esp_system.h>
@@ -79,7 +81,9 @@ RTC_DATA_ATTR struct GSRDrift final {
 
 class SmallRTC {
     public:
+#ifndef SMALL_RTC_NO_DS3232
         DS3232RTC rtc_ds;
+#endif
         Rtc_Pcf8563 rtc_pcf;
     public:
         SmallRTC();


### PR DESCRIPTION
For people who don't have DS3232 and don't want to unnecessarily include it.

For some reason the SmallRTC.h was being included automatically so i just added `-D SMALL_RTC_NO_DS3232=1`